### PR TITLE
Fix Message-Id field in email and comment

### DIFF
--- a/send-pr
+++ b/send-pr
@@ -149,7 +149,7 @@ Dir.mktmpdir do |dir|
       end
 
       note = "This pull request has been submitted to " +
-        options[:to] + " as Message-Id: <#{msg_id}>, count: #{reroll_count}"
+        options[:to] + " as Message-Id: #{msg_id}, count: #{reroll_count}"
 
       text.gsub!(/[*]{3} SUBJECT HERE [*]{3}/, pr[:title])
       text.gsub!(/[*]{3} BLURB HERE [*]{3}/, note + "\n\n" +


### PR DESCRIPTION
Strip on pair of '<>' from the Message-Id in the email and the pull
request comment.

Closes-Bug: #12